### PR TITLE
Fix instruments initialization in SyntheticExchange.

### DIFF
--- a/aat/exchange/synthetic/__init__.py
+++ b/aat/exchange/synthetic/__init__.py
@@ -74,7 +74,7 @@ class SyntheticExchange(Exchange):
 
     def _seed(self, symbols: List[str] = None) -> None:
         self._instruments = {
-            symbol: Instrument(symbol)
+            symbol: Instrument(symbol, exchange=self.exchange())
             for symbol in symbols or _getName(self._inst_count)
         }
         self._orderbooks = {


### PR DESCRIPTION
Because of an initialization of instruments without ExchangeType,  Running with the below configuration was failed at the current main branch (27ad596439d4c9c7df44d6526b3951b7c9b12d58 ).

```config
[general]
verbose=0
trading_type=backtest

[exchange]
exchanges=
    aat.exchange:SyntheticExchange

[strategy]
strategies =
    aat.strategy.sample.readonly:ReadOnlyStrategy
```
